### PR TITLE
Minor updates

### DIFF
--- a/client/src/components/dashboardComponents/Flags.jsx
+++ b/client/src/components/dashboardComponents/Flags.jsx
@@ -8,17 +8,11 @@ import { handleErrorRedirect } from '../../lib/helpers';
 
 
 const sortFlags = (flagList) => {
-  flagList.sort((a, b) => {
-    if (a.updated_at < b.updated_at) {
-      return 1
-    } else if (a.updated_at > b.updated_at) {
-      return -1
-    } else {
-      return 0
-    }
+  return flagList.sort((a, b) => {
+    const titleA = a.title.toLowerCase();
+    const titleB = b.title.toLowerCase();
+    return (titleA < titleB) ? -1 : (titleB > titleA) ? 1 : 0;
   });
-
-  return flagList
 }
 
 const Flags = () => {

--- a/client/src/components/dashboardComponents/Flags.jsx
+++ b/client/src/components/dashboardComponents/Flags.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { fetchFlags } from '../../actions/FlagActions';
 import Flag from './Flag';
+import Search from '../sharedComponents/Search';
 import PageHead from '../sharedComponents/PageHead';
 import NewFlagForm from './NewFlagForm';
 import { handleErrorRedirect } from '../../lib/helpers';
@@ -16,10 +17,18 @@ const sortFlags = (flagList) => {
 }
 
 const Flags = () => {
-  const flagList = sortFlags(useSelector(state => state.flags));
+  let flagList = sortFlags(useSelector(state => state.flags));
   const error = useSelector(state => state.errors);
   const dispatch = useDispatch();
   const [creatingNew, setCreatingNew] = useState(false);
+  const [searchWord, setSearchWord] = useState("");
+
+  if (searchWord !== "") {
+    flagList = flagList.filter(flag => {
+      const title = flag.title.toLowerCase();
+      return title.indexOf(searchWord.toLowerCase()) !== -1;
+    });
+  }
 
   useEffect(() => {
     dispatch(fetchFlags());
@@ -31,10 +40,11 @@ const Flags = () => {
   return (
     <>
       <PageHead title={'Feature Flags'} description={pageDesc} setCreatingNew={setCreatingNew} />
-
       <NewFlagForm creatingNew={creatingNew} setCreatingNew={setCreatingNew} existingFlags={flagList} />
-      <section className="flag-container">
-        <ul className="p-8 flag-tiles">
+
+      <section className="p-8 pt-0 flag-container">
+        <Search searchWord={searchWord} setSearchWord={setSearchWord} />
+        <ul className="pb-8 pt-4 flag-tiles">
           {flagList.map(flag => <Flag {...flag} key={flag.id} />)}
         </ul>
       </section>

--- a/client/src/components/sharedComponents/FlagForm.jsx
+++ b/client/src/components/sharedComponents/FlagForm.jsx
@@ -1,6 +1,6 @@
 // flag form will take state/set for form visibility, and an arg to define the context('edit' or 'new')
 // title, desc, rollout as well
-// it will need to accecpt methods for handleCancel, resetFields, handleSubmit
+// it will need to accept methods for handleCancel, resetFields, handleSubmit
 // it will define handle value change methods 50-62
 // the html will have conditional rendering for the title and description labels
 

--- a/client/src/components/sharedComponents/Search.jsx
+++ b/client/src/components/sharedComponents/Search.jsx
@@ -10,9 +10,9 @@ function Search({searchWord, setSearchWord}) {
     <input
       onChange={handleSearchChange}
       type="text"
-      placeholder="Search..."
+      placeholder="Search by flag title..."
       autoComplete="given-name"
-      className="max-w-lg block w-full shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:max-w-xs sm:text-sm border-gray-300 rounded-md"
+      className="float-right my-4 max-w-lg block w-full shadow-sm focus:ring-pioneerBlue-400 focus:border-pioneerBlue-400 sm:max-w-xs sm:text-sm border-gray-300 rounded-md"
       value={searchWord}
     />
   )

--- a/client/src/components/sharedComponents/Search.jsx
+++ b/client/src/components/sharedComponents/Search.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+function Search({searchWord, setSearchWord}) {
+  const handleSearchChange = (e) => {
+    e.preventDefault();
+    setSearchWord(e.target.value);
+  };
+
+  return (
+    <input
+      onChange={handleSearchChange}
+      type="text"
+      placeholder="Search..."
+      autoComplete="given-name"
+      className="max-w-lg block w-full shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:max-w-xs sm:text-sm border-gray-300 rounded-md"
+      value={searchWord}
+    />
+  )
+}
+
+export default Search


### PR DESCRIPTION
This PR does the following:

1. sorts flags on the dashboard by alphabetic order, as suggested by Julius.  This avoids the jumpy behavior seen previously when a user toggles a flag on the last on/off.

2. adds a search bar to the dashboard page (built by Jimmy). The search bar filters the list of flags by title. You can run locally to test that functionality out, but here is a screenshot of the look:

<img width="1253" alt="Screen Shot 2021-07-30 at 7 25 42 AM" src="https://user-images.githubusercontent.com/19399698/127655364-d87a0083-9f06-4855-a6d5-aa98cd7d8872.png">
