### PR TITLE
Color update

### DIFF
--- a/client/src/components/Sidebar.jsx
+++ b/client/src/components/Sidebar.jsx
@@ -1,45 +1,98 @@
 import React from 'react';
 
 const isCurrentPage = (href) => {
-  const currentPath = window.location.pathname;
-  return href === currentPath;
-}
+	const currentPath = window.location.pathname;
+	return href === currentPath;
+};
 
 const Sidebar = () => {
-  return(
-    <div className="flex flex-col w-64 bg-gray-800">
-      <div className="flex flex-col h-0 flex-1 bg-gray-800">
-        <div className="flex-1 flex flex-col pt-5 pb-4 overflow-y-auto">
-          <div className=" items-center flex-shrink-0 px-4">
-              <img className="flex items-center" src={process.env.PUBLIC_URL + '/images/pioneer_ui_logo.png'} alt="pioneer logo"></img>
-          </div>
-          <nav className='mt-5 flex-1 px-2 space-y-1 bg-gray-800'>
-            <a href="/flags" className={`${(isCurrentPage('/flags') || isCurrentPage('/')) ? 'bg-black' : 'bg-gray-800'} text-white group flex items-center px-2 py-2 text font-medium rounded-md`}>
+	return (
+		<div className="flex flex-col w-64 bg-pioneerBlue-500">
+			<div className="flex flex-col h-0 flex-1 bg-pioneerBlue-500">
+				<div className="flex-1 flex flex-col pt-5 pb-4 overflow-y-auto">
+					<div className=" items-center flex-shrink-0 px-4">
+						<img
+							className="flex items-center"
+							src={process.env.PUBLIC_URL + '/images/pioneer_ui_logo.png'}
+							alt="pioneer logo"
+						/>
+					</div>
+					<nav className="mt-5 flex-1 px-2 space-y-1 bg-pioneerBlue-500">
+						<a
+							href="/flags"
+							className={`${isCurrentPage('/flags') || isCurrentPage('/')
+								? 'bg-pioneerBlue-900'
+								: 'bg-pioneerBlue-500'} text-white group flex items-center px-2 py-2 text font-medium rounded-md`}
+						>
+							<svg
+								className="text-gray-300 mr-3 flex-shrink-0 h-6 w-6"
+								xmlns="http://www.w3.org/2000/svg"
+								fill="none"
+								viewBox="0 0 24 24"
+								stroke="currentColor"
+								aria-hidden="true"
+							>
+								<path
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									strokeWidth="2"
+									d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
+								/>
+							</svg>
+							Dashboard
+						</a>
 
-              <svg className="text-gray-300 mr-3 flex-shrink-0 h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
-              </svg>
-              Dashboard
-            </a>
+						<a
+							href="/logs"
+							className={`${isCurrentPage('/logs')
+								? 'bg-pioneerBlue-900'
+								: 'bg-pioneerBlue-500'} text-white group flex items-center px-2 py-2 text font-medium rounded-md`}
+						>
+							<svg
+								className="text-gray-400 group-hover:text-gray-300 mr-3 flex-shrink-0 h-6 w-6"
+								xmlns="http://www.w3.org/2000/svg"
+								fill="none"
+								viewBox="0 0 24 24"
+								stroke="currentColor"
+								aria-hidden="true"
+							>
+								<path
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									strokeWidth="2"
+									d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
+								/>
+							</svg>
+							Logs
+						</a>
 
-            <a href="/logs" className={`${isCurrentPage('/logs') ? 'bg-black' : 'bg-gray-800'} text-white group flex items-center px-2 py-2 text font-medium rounded-md`}>
-              <svg className="text-gray-400 group-hover:text-gray-300 mr-3 flex-shrink-0 h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
-              </svg>
-              Logs
-            </a>
-
-            <a href="/account" className={`${isCurrentPage('/account') ? 'bg-black' : 'bg-gray-800'} text-white hover:bg-gray-700 hover:text-white group flex items-center px-2 py-2 text font-medium rounded-md`}>
-              <svg xmlns="http://www.w3.org/2000/svg" className="text-gray-400 group-hover:text-gray-300 mr-3 flex-shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
-              </svg>
-                Account
-              </a>
-          </nav>
-        </div>
-      </div>
-    </div>
-  );
+						<a
+							href="/account"
+							className={`${isCurrentPage('/account')
+								? 'bg-pioneerBlue-900'
+								: 'bg-pioneerBlue-500'} text-white hover:bg-pioneerBlue-700 hover:text-white group flex items-center px-2 py-2 text font-medium rounded-md`}
+						>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								className="text-gray-400 group-hover:text-gray-300 mr-3 flex-shrink-0 h-6 w-6"
+								fill="none"
+								viewBox="0 0 24 24"
+								stroke="currentColor"
+							>
+								<path
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									strokeWidth="2"
+									d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"
+								/>
+							</svg>
+							Account
+						</a>
+					</nav>
+				</div>
+			</div>
+		</div>
+	);
 };
 
 export default Sidebar;

--- a/client/src/components/Sidebar.jsx
+++ b/client/src/components/Sidebar.jsx
@@ -22,10 +22,10 @@ const Sidebar = () => {
 							href="/flags"
 							className={`${isCurrentPage('/flags') || isCurrentPage('/')
 								? 'bg-pioneerBlue-900'
-								: 'bg-pioneerBlue-500'} text-white group flex items-center px-2 py-2 text font-medium rounded-md`}
+								: 'bg-pioneerBlue-500'} text-white hover:bg-pioneerBlue-700 hover:text-white group flex items-center px-2 py-2 text font-medium rounded-md`}
 						>
 							<svg
-								className="text-gray-300 mr-3 flex-shrink-0 h-6 w-6"
+								className="text-gray-400 group-hover:text-gray-300 mr-3 flex-shrink-0 h-6 w-6"
 								xmlns="http://www.w3.org/2000/svg"
 								fill="none"
 								viewBox="0 0 24 24"
@@ -46,7 +46,7 @@ const Sidebar = () => {
 							href="/logs"
 							className={`${isCurrentPage('/logs')
 								? 'bg-pioneerBlue-900'
-								: 'bg-pioneerBlue-500'} text-white group flex items-center px-2 py-2 text font-medium rounded-md`}
+								: 'bg-pioneerBlue-500'} text-white hover:bg-pioneerBlue-700 hover:text-white group flex items-center px-2 py-2 text font-medium rounded-md`}
 						>
 							<svg
 								className="text-gray-400 group-hover:text-gray-300 mr-3 flex-shrink-0 h-6 w-6"

--- a/client/src/components/accountComponents/Account.jsx
+++ b/client/src/components/accountComponents/Account.jsx
@@ -44,20 +44,17 @@ const Account = () => {
       <PageHead title={'Your Account'} description={pageDesc} />
       <div className="p-8 max-w-7xl sm:px-6 lg:px-8">
         <h3 className="mb-2 text-xl text-green-700 font-header">Your SDK key</h3>
-        <p className="bg-gray-200 rounded h-10 w-max p-2.5">{renderText()}</p>
+        <p className="bg-pioneerBlue-100 rounded h-10 w-max p-2.5">{renderText()}</p>
         <div className="clear-both py-10 mb-10">
           <button
           onClick={generateSDKKey}
           type="button"
-          className="float-left inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-pioneerBlue-400 hover:bg-pioneerBlue-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pioneerBlue-500"
+          className="float-left inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-pioneerBlue-500 hover:bg-pioneerBlue-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pioneerBlue-500"
           >
             Generate new SDK key
           </button>
         </div>
       </div>
-      
-        
-        {/*<p className="pt-1 text-right text-sm text-gray-700 w-1/3 clear-both float-right inline-flex px-2">Generating a new key will invalidate any currently existing SDK key. You will need to use the new SDK key in your application code.</p>*/}
     </>
   );
 };

--- a/client/src/components/flagViewComponents/DeleteFlagModal.jsx
+++ b/client/src/components/flagViewComponents/DeleteFlagModal.jsx
@@ -36,14 +36,14 @@ const DeleteConfirmationModal = ({ deletingFlag, setDeletingFlag, flag, history 
 							<button
 								onClick={handleSubmit}
 								type="button"
-								className="ml-5 float-right inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-pioneerRed-700 hover:bg-pioneerRed-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pioneerRed-700"
+								className="ml-5 float-right inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-pioneerRed-600 hover:bg-pioneerRed-500 hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pioneerRed-600"
 							>
 								Delete Flag!
 							</button>
 							<button
 								type="button"
 								onClick={handleCancel}
-								className="float-right inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-pioneerBlue-500 hover:bg-pioneerBlue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pioneerBlue-200"
+								className="float-right inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-pioneerBlue-500 hover:bg-pioneerBlue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pioneerBlue-500"
 							>
 								Nevermind, cancel.
 							</button>

--- a/client/src/components/flagViewComponents/SingleFlag.jsx
+++ b/client/src/components/flagViewComponents/SingleFlag.jsx
@@ -119,13 +119,13 @@ const SingleFlag = (props) => {
       </div>
     </div>
     <div className="clear-both py-5 mb-10 ml-5 mr-5">
-        <button onClick={handleDeleteFlag}type="button" className="shadow ml-5 float-right inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md bg-pioneerRed-700 hover:bg-pioneerRed-900 text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500">
+        <button onClick={handleDeleteFlag}type="button" className="shadow ml-5 float-right inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md bg-pioneerRed-600 hover:bg-pioneerRed-500 text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pioneerRed-600">
           Delete flag
         </button>
-        <button onClick={handleEditFlag} type="button" className="shadow float-right inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white-100 bg-pioneerBlue-400 hover:bg-pioneerBlue-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+        <button onClick={handleEditFlag} type="button" className="shadow float-right inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white-100 bg-pioneerBlue-400 hover:bg-pioneerBlue-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pioneerBlue-500">
           Edit flag
         </button>
-        <button onClick={() => {props.history.push('/')}} type="button" className="shadow float-left inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-pioneerBlue-400 hover:bg-pioneerBlue-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+        <button onClick={() => {props.history.push('/')}} type="button" className="shadow float-left inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-pioneerBlue-400 hover:bg-pioneerBlue-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pioneerBlue-500">
           Back to Dashboard
         </button>
     </div>

--- a/client/src/components/sharedComponents/FlagForm.jsx
+++ b/client/src/components/sharedComponents/FlagForm.jsx
@@ -103,14 +103,14 @@ const FlagForm = ({
 							<button
 								onClick={handleSubmit}
 								type="button"
-								className="ml-5 float-right inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-pioneerBlue-600 hover:bg-pioneerBlue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pioneerBlue-500"
+								className="ml-5 float-right inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-pioneerBlue-500 hover:bg-pioneerBlue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pioneerBlue-500"
 							>
 								Save
 							</button>
 							<button
 								type="button"
 								onClick={handleCancel}
-								className="float-right inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-pioneerBlue-100 hover:bg-pioneerBlue-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pioneerBlue-500"
+								className="float-right inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-pioneerBlue-200 hover:bg-pioneerBlue-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pioneerBlue-500"
 							>
 								Cancel
 							</button>

--- a/client/src/components/sharedComponents/PageHead.jsx
+++ b/client/src/components/sharedComponents/PageHead.jsx
@@ -17,7 +17,7 @@ const PageHead = ({ title, description, setCreatingNew }) => {
 					type="button"
 					className={`${isDashboard(title)
 						? 'inline-flex'
-						: 'hidden'} items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-700 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500`}
+						: 'hidden'} items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-700 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pioneerBlue-500`}
 				>
 					Create new flag
 				</button>

--- a/client/src/components/sharedComponents/Toggle.jsx
+++ b/client/src/components/sharedComponents/Toggle.jsx
@@ -1,18 +1,34 @@
 import React from 'react';
 
-const Toggle = ({toggledOn, handleClickToggle}) => {
-  const classList = toggledOn ? "bg-green-700" : "bg-gray-200";
-  const translation = toggledOn ? "translate-x-7" : "translate-x-0";
+const Toggle = ({ toggledOn, handleClickToggle }) => {
+	const classList = toggledOn ? 'bg-green-700' : 'bg-pioneerBlue-200';
+	const translation = toggledOn ? 'translate-x-7' : 'translate-x-0';
 
-  return(
-    <div className="flex float-right">
-      <span className="flex-grow flex flex-col">
-      </span>
-      <button onClick={handleClickToggle} type="button" className={classList + " relative inline-flex flex-shrink-0 h-8 w-16 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 ml-2"} role="switch" aria-checked="false" aria-labelledby="availability-label" aria-describedby="availability-description">
-        <span aria-hidden="true" className={translation + " pointer-events-none inline-block h-7 w-7 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200"}></span>
-      </button>
-    </div>
-  );
+	return (
+		<div className="flex float-right">
+			<span className="flex-grow flex flex-col" />
+			<button
+				onClick={handleClickToggle}
+				type="button"
+				className={
+					classList +
+					' relative inline-flex flex-shrink-0 h-8 w-16 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pioneerBlue-500 ml-2'
+				}
+				role="switch"
+				aria-checked="false"
+				aria-labelledby="availability-label"
+				aria-describedby="availability-description"
+			>
+				<span
+					aria-hidden="true"
+					className={
+						translation +
+						' pointer-events-none inline-block h-7 w-7 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200'
+					}
+				/>
+			</button>
+		</div>
+	);
 };
 
 export default Toggle;

--- a/client/tailwind.js
+++ b/client/tailwind.js
@@ -20,17 +20,17 @@ module.exports = {
 			}
 		},
 		colors                   : {
-			transparent  : 'transparent',
-			current      : 'currentColor',
-			black        : colors.black,
-			gray         : colors.coolGray,
-			yellow       : colors.amber,
-			green        : colors.emerald,
-			blue         : colors.blue,
-			indigo       : colors.indigo,
-			purple       : colors.violet,
-			pink         : colors.pink,
-			white        : {
+			transparent : 'transparent',
+			current     : 'currentColor',
+			black       : colors.black,
+			gray        : colors.coolGray,
+			yellow      : colors.amber,
+			green       : colors.emerald,
+			blue        : colors.blue,
+			indigo      : colors.indigo,
+			purple      : colors.violet,
+			pink        : colors.pink,
+			white       : {
 				DEFAULT : '#F5F5F5',
 				100     : '#fcfcfc',
 				200     : '#fafafa',
@@ -42,48 +42,32 @@ module.exports = {
 				800     : '#acacac',
 				900     : '#939393'
 			},
-			pioneerRed   : {
+			pioneerRed  : {
 				DEFAULT : '#f45459',
-				100     : '#fde7e6',
-				200     : '#fbcfcd',
-				300     : '#f8b8b5',
-				400     : '#f6a09c',
-				500     : '#f48883',
-				600     : '#f17973',
-				700     : '#f45459',
-				800     : '#ef6d67',
-				900     : '#d7625d'
+				100     : '#fccccd',
+				200     : '#faaaac',
+				300     : '#f7878b',
+				400     : '#f5656a',
+				500     : '#f45459',
+				600     : '#dc4c50',
+				700     : '#c34347',
+				800     : '#ab3b3e',
+				900     : '#923235'
 			},
-			pioneerGreen : {
-				DEFAULT : '#9ebeb9',
-				100     : '#e2ecea',
-				200     : '#cfdfdc',
-				300     : '#bbd2ce',
-				400     : '#a8c5c0',
-				500     : '#9ebeb9',
-				600     : '#8eaba7',
-				700     : '#7e9894',
-				800     : '#6f8582',
-				900     : '#5f726f'
+			pioneerBlue : {
+				DEFAULT : '#314359',
+				100     : '#c1c7cd',
+				200     : '#98a1ac',
+				300     : '#6f7b8b',
+				400     : '#46566a',
+				500     : '#314359',
+				600     : '#2c3c50',
+				700     : '#273647',
+				800     : '#222f3e',
+				900     : '#1d2835'
 			},
-			pioneerBlue  : {
-				DEFAULT : '#1a4451',
-				100     : '#bac7cb',
-				200     : '#8da2a8',
-				300     : '#5f7c85',
-				400     : '#315762',
-				500     : '#1a4451',
-				600     : '#173d49',
-				700     : '#153641',
-				800     : '#123039',
-				900     : '#102931'
-			},
-			dodgerBlue	: {
-				500: '#005a9c'
-			},
-			pioneerDarkBlue  : {
-				DEFAULT: '314359',
-				900: '314359'
+			dodgerBlue  : {
+				500 : '#005a9c'
 			}
 		},
 		spacing                  : {


### PR DESCRIPTION
I took a last pass at color work presentation for Compass.
With the new logo colors finalized, I updated the frontend to be consistent (mostly) with our branding colors.
A few things to note:

- Color palettes in `tailwind.js` were updated to contain new shades based on the new color schemes
- Sidebar was changed to match the main blue of the logo. This means the logo blends more with the background, but I think it actually looks just fine.
![Screenshot from 2021-07-30 11-22-56](https://user-images.githubusercontent.com/42515081/127676402-e7d1f347-9756-4d4a-bd13-963c9b8872ec.png)
- The sidebar also had some formatting issues where two out of the three choices in the nav menu weren't highlighting appropriately; that has been fixed.

I opted to leave the forest green in as I think it works just fine and compliments the overall aesthetic.