### PR TITLE
Sdk modal

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,10 +1,11 @@
 {
-  "name": "client",
+  "name": "compass-frontend",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "compass-frontend",
       "version": "0.1.0",
       "dependencies": {
         "@tailwindcss/forms": "^0.3.3",

--- a/client/src/actions/sdkKeyActions.js
+++ b/client/src/actions/sdkKeyActions.js
@@ -3,39 +3,40 @@ import apiClient from '../lib/ApiClient';
 import { sdkKeyError } from './ErrorActions';
 
 export function fetchSdkKeyRequest() {
-	return {type: types.FETCH_SDK_KEY_REQUEST};
+	return { type: types.FETCH_SDK_KEY_REQUEST };
 }
 
 export function fetchSdkKeySuccess(data) {
-	return { type: types.FETCH_SDK_KEY_SUCCESS, sdkKey: data.sdkKey}
+	return { type: types.FETCH_SDK_KEY_SUCCESS, sdkKey: data.sdkKey };
 }
 
 export function createSdkKeyRequest() {
-	return {type: types.CREATE_SDK_KEY_REQUEST};
+	return { type: types.CREATE_SDK_KEY_REQUEST };
 }
 
 export function createSdkKeySuccess(data) {
-	return {type: types.CREATE_SDK_KEY_SUCCESS, sdkKey: data.sdkKey};
+	return { type: types.CREATE_SDK_KEY_SUCCESS, sdkKey: data.sdkKey };
 }
 
 export function fetchSdkKey() {
-  return function(dispatch) {
-    dispatch(fetchSdkKeyRequest());
-		apiClient.getSdkKey((data) => {
-			dispatch(fetchSdkKeySuccess(data))
-		})
-		.catch(error => dispatch(sdkKeyError(error)))
-  };
+	return function(dispatch) {
+		dispatch(fetchSdkKeyRequest());
+		apiClient
+			.getSdkKey((data) => {
+				dispatch(fetchSdkKeySuccess(data));
+			})
+			.catch((error) => dispatch(sdkKeyError(error)));
+	};
 }
 
 export function createNewSdkKey() {
 	return function(dispatch) {
 		dispatch(createSdkKeyRequest());
-		console.log('hello')
-		apiClient.createSdkKey(data => {
-			console.log(`data from create sdk key: ${data}`)
-			dispatch(createSdkKeySuccess(data))
-		})
-			.catch(error => dispatch(sdkKeyError(error)))
+		apiClient
+			.createSdkKey((data) => {
+				console.log(`data from create sdk key: ${data}`);
+				dispatch(createSdkKeySuccess(data));
+			})
+			.catch((error) => dispatch(sdkKeyError(error)));
 	};
 }

--- a/client/src/components/accountComponents/Account.jsx
+++ b/client/src/components/accountComponents/Account.jsx
@@ -1,9 +1,11 @@
-import React, {useEffect} from 'react';
+import React, {useEffect, useState} from 'react';
 import PageHead from '../sharedComponents/PageHead';
+import Modal from '../sharedComponents/Modal';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchSdkKey, createNewSdkKey } from '../../actions/sdkKeyActions';
 
 const Account = () => {
+	const [ creatingKey, setCreatingKey ] = useState(false)
   const dispatch = useDispatch();
   const sdkKey = useSelector(state => state.sdkKey);
   
@@ -13,6 +15,7 @@ const Account = () => {
   
   const generateSDKKey = () => {
     dispatch(createNewSdkKey());
+		setCreatingKey(false)
   }
 
   const renderText = () => {
@@ -25,12 +28,12 @@ const Account = () => {
       return (
         <p>{sdkKey}
           <button id="copy-key">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 inline mx-2" stroke="currentColor" fill="none" viewBox="0 0 24 24" onClick={copyText}>
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 inline mx-2" stroke="currentColor" fill="none" viewBox="0 0 24 24" onClick={copyText}>
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
             </svg>
           </button>
-          {/*<button onClick={copyText} className="ml-3 text-sm text-green-900">Copy to Clipboard</button>*/}
-        </p>);
+        </p>
+				);
     } else {
       return <p>You don't have an SDK key yet. You can click below to generate one.</p>
     }
@@ -40,14 +43,15 @@ const Account = () => {
   const pageDesc = 'In your application, provide the SDK key to create an SDK client connection to Scout. This will allow you to receive updated rulesets related to your feature flags.';
   
   return (
-    <>
+		<>
       <PageHead title={'Your Account'} description={pageDesc} />
+			<Modal modifyingModalStatus={creatingKey} setModifyingModalStatus={setCreatingKey} handleSubmit={generateSDKKey} modalType={'sdk'}></Modal>
       <div className="p-8 max-w-7xl sm:px-6 lg:px-8">
         <h3 className="mb-2 text-xl text-green-700 font-header">Your SDK key</h3>
-        <p className="bg-pioneerBlue-100 rounded h-10 w-max p-2.5">{renderText()}</p>
+        <div className="bg-pioneerBlue-100 rounded h-10 w-max p-2.5">{renderText()}</div>
         <div className="clear-both py-10 mb-10">
           <button
-          onClick={generateSDKKey}
+          onClick={()=> setCreatingKey(true)}
           type="button"
           className="float-left inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-pioneerBlue-500 hover:bg-pioneerBlue-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pioneerBlue-500"
           >
@@ -55,7 +59,7 @@ const Account = () => {
           </button>
         </div>
       </div>
-    </>
+			</>
   );
 };
 

--- a/client/src/components/flagViewComponents/DeleteFlagModal.jsx
+++ b/client/src/components/flagViewComponents/DeleteFlagModal.jsx
@@ -1,14 +1,11 @@
 import React from 'react';
+import Modal from '../sharedComponents/Modal';
 import { logFlagDeletion } from '../../actions/LogActions';
 import { useDispatch } from 'react-redux';
 import { deleteFlag } from '../../actions/FlagActions';
 
 const DeleteConfirmationModal = ({ deletingFlag, setDeletingFlag, flag, history }) => {
 	const dispatch = useDispatch();
-
-	const handleCancel = () => {
-		setDeletingFlag(false);
-	};
 
 	const handleSubmit = () => {
 		dispatch(
@@ -19,39 +16,12 @@ const DeleteConfirmationModal = ({ deletingFlag, setDeletingFlag, flag, history 
 	};
 
 	return (
-		<div id="modal-container" className={`overflow-scroll fixed ${deletingFlag ? '' : 'hidden'}`}>
-			<div id="modal">
-				<form className="space-y-8 divide-y divide-gray-200 m-8">
-					<div className="space-y-8 divide-y divide-gray-200 sm:space-y-5 p-6">
-						<div>
-							<div>
-								<h3 className="text-lg leading-6 font-medium text-gray-900 font-header">Delete Flag?</h3>
-								<p className="mt-1 max-w-2xl text-sm text-gray-500">
-									Do you really want to delete this flag? This can't be undone, so please make sure there will be no
-									impacts to your SDKs!
-								</p>
-							</div>
-						</div>
-						<div className="clear-both py-10 mb-10">
-							<button
-								onClick={handleSubmit}
-								type="button"
-								className="ml-5 float-right inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-pioneerRed-600 hover:bg-pioneerRed-500 hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pioneerRed-600"
-							>
-								Delete Flag!
-							</button>
-							<button
-								type="button"
-								onClick={handleCancel}
-								className="float-right inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-pioneerBlue-500 hover:bg-pioneerBlue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pioneerBlue-500"
-							>
-								Nevermind, cancel.
-							</button>
-						</div>
-					</div>
-				</form>
-			</div>
-		</div>
+		<Modal
+			modifyingModalStatus={deletingFlag}
+			setModifyingModalStatus={setDeletingFlag}
+			handleSubmit={handleSubmit}
+			modalType={'delete'}
+		/>
 	);
 };
 

--- a/client/src/components/sharedComponents/Modal.jsx
+++ b/client/src/components/sharedComponents/Modal.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+const Modal = ({ modifyingModalStatus, setModifyingModalStatus, handleSubmit, modalType }) => {
+	const handleCancel = () => {
+		setModifyingModalStatus(false);
+	};
+
+	return (
+		<div id="modal-container" className={`overflow-scroll fixed ${modifyingModalStatus ? '' : 'hidden'}`}>
+			<div id="modal">
+				<form className="space-y-8 divide-y divide-gray-200 m-8">
+					<div className="space-y-8 divide-y divide-gray-200 sm:space-y-5 p-6">
+						<div>
+							<div>
+								<h3 className="text-lg leading-6 font-medium text-gray-900 font-header">
+									{modalType === 'delete' ? 'Delete Flag?' : 'Create New SDK Key?'}
+								</h3>
+								<p className="mt-1 max-w-2xl text-sm text-gray-500">
+									Do you really want to {modalType === 'delete' ? 'delete this flag?' : 'create a new SDK Key?'} This
+									can't be undone, so please make sure there will be no impacts to your SDKs!
+								</p>
+							</div>
+						</div>
+						<div className="clear-both py-10 mb-10">
+							<button
+								onClick={handleSubmit}
+								type="button"
+								className="ml-5 float-right inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-pioneerRed-600 hover:bg-pioneerRed-500 hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pioneerRed-600"
+							>
+								{modalType === 'delete' ? 'Delete Flag!' : 'Create New Key!'}
+							</button>
+							<button
+								type="button"
+								onClick={handleCancel}
+								className="float-right inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-pioneerBlue-500 hover:bg-pioneerBlue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pioneerBlue-500"
+							>
+								Nevermind, cancel.
+							</button>
+						</div>
+					</div>
+				</form>
+			</div>
+		</div>
+	);
+};
+
+export default Modal;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "monolith-prototype",
+	"name": "compass-backend",
 	"version": "1.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "monolith-prototype",
+			"name": "compass-backend",
 			"version": "1.0.0",
 			"license": "ISC",
 			"dependencies": {


### PR DESCRIPTION
In this branch I've extracted the modal component from the `DeleteConfirmationModal` and made it reusable elsewhere. 
Aside from general re-usability, the main goal for splitting it out was to be able to include a modal in the `Account` component, so users will be warned before changing their SDK key, as this will be a breaking change, just the same as deleting a flag. 

The extraction was simple and we leave the action to be completed on submission of the modal form to be defined by the parent component in which is defined. (The `handleSubmit` function is passed down from the parent component into the `Modal`) This lets us keep the modal component as clean as possible and free from concerns of how it is being used.
For example, in the `DeleteFormModal` the funciton is defined and passed in as such:
```js
const handleSubmit = () => {
  dispatch(
    deleteFlag(flag, () => {
      dispatch(logFlagDeletion(flag, () => history.push('/flags')));
    })
  );
};
```

The text content was is currently a simple ternary operator that will render either delete text or sdk key text based on the value of a param `modalType`. There is certainly room for improvement here, particularly if this is to be reused more widely. But for now, for our purpose it is reusable enough!

Basic integration tests indicate that this is functional.